### PR TITLE
Implement study path service and JWT auth middleware

### DIFF
--- a/src/co/server.py
+++ b/src/co/server.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 
 from co.config import get_settings
 from co.db.base import close_db, init_db
-from co.middleware import RateLimitMiddleware, RequestIDMiddleware
+from co.middleware import AuthMiddleware, RateLimitMiddleware, RequestIDMiddleware
 from co.routes import sessions, submissions, tracks, tutor
 
 
@@ -46,6 +46,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.add_middleware(RequestIDMiddleware)
+    app.add_middleware(AuthMiddleware)
     app.add_middleware(RateLimitMiddleware)
 
     # Routes

--- a/src/co/services/study_path.py
+++ b/src/co/services/study_path.py
@@ -1,0 +1,105 @@
+"""Study path service layer."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from redis import asyncio as aioredis
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from co.config import get_settings
+from co.models import StudyPath
+
+
+class StudyPathService:
+    """Service for managing study paths."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.settings = get_settings()
+        self._redis: Optional[aioredis.Redis] = None
+
+    async def _get_redis(self) -> aioredis.Redis:
+        if not self._redis:
+            self._redis = await aioredis.from_url(self.settings.redis_url)
+        return self._redis
+
+    def _cache_key(self, user_id: str) -> str:
+        return f"study_path:active:{user_id}"
+
+    async def create_study_path(
+        self, user_id: str, track_id: str, config: dict
+    ) -> StudyPath:
+        """Create a new study path and cache it as active."""
+        path = StudyPath(user_id=user_id, track_id=track_id, config=config)
+        self.db.add(path)
+        await self.db.commit()
+        await self.db.refresh(path)
+
+        redis = await self._get_redis()
+        await redis.set(self._cache_key(user_id), json.dumps(self._serialize(path)))
+        return path
+
+    async def get_active_path(self, user_id: str) -> Optional[StudyPath]:
+        """Get the user's active study path using Redis cache."""
+        redis = await self._get_redis()
+        cached = await redis.get(self._cache_key(user_id))
+        if cached:
+            return self._deserialize(cached)
+
+        result = await self.db.execute(
+            select(StudyPath)
+            .where(StudyPath.user_id == user_id)
+            .order_by(StudyPath.created_at.desc())
+            .limit(1)
+        )
+        path = result.scalar_one_or_none()
+        if path:
+            await redis.set(
+                self._cache_key(user_id), json.dumps(self._serialize(path))
+            )
+        return path
+
+    async def update_path_config(
+        self, path_id: UUID, config: dict
+    ) -> StudyPath:
+        """Update study path configuration and refresh cache."""
+        path = await self.db.get(StudyPath, path_id)
+        if not path:
+            raise ValueError("Study path not found")
+
+        path.config = config
+        path.updated_at = datetime.utcnow()
+        await self.db.commit()
+        await self.db.refresh(path)
+
+        redis = await self._get_redis()
+        await redis.set(
+            self._cache_key(path.user_id), json.dumps(self._serialize(path))
+        )
+        return path
+
+    def _serialize(self, path: StudyPath) -> dict[str, Any]:
+        return {
+            "id": str(path.id),
+            "user_id": path.user_id,
+            "track_id": path.track_id,
+            "config": path.config,
+            "created_at": path.created_at.isoformat(),
+            "updated_at": path.updated_at.isoformat(),
+        }
+
+    def _deserialize(self, data: bytes) -> StudyPath:
+        obj = json.loads(data)
+        return StudyPath(
+            id=UUID(obj["id"]),
+            user_id=obj["user_id"],
+            track_id=obj["track_id"],
+            config=obj.get("config", {}),
+            created_at=datetime.fromisoformat(obj["created_at"]),
+            updated_at=datetime.fromisoformat(obj["updated_at"]),
+        )

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+
+from co.auth import get_current_user
+from co.middleware import AuthMiddleware
+
+
+@pytest.fixture
+def auth_app():
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+
+    @app.get("/state")
+    async def read_state(request: Request):
+        return {"user_id": getattr(request.state, "user_id", None)}
+
+    @app.get("/me")
+    async def read_me(user_id=Depends(get_current_user)):
+        return {"user_id": str(user_id)}
+
+    return app
+
+
+def test_auth_middleware_sets_user_id(auth_app, test_jwt_token, test_user_id):
+    client = TestClient(auth_app)
+    response = client.get("/state", headers={"Authorization": f"Bearer {test_jwt_token}"})
+    assert response.status_code == 200
+    assert response.json()["user_id"] == test_user_id
+
+    # Ensure dependency uses middleware value
+    me_resp = client.get("/me", headers={"Authorization": f"Bearer {test_jwt_token}"})
+    assert me_resp.status_code == 200
+    assert me_resp.json()["user_id"] == test_user_id
+
+
+def test_auth_middleware_invalid_token(auth_app):
+    client = TestClient(auth_app)
+    response = client.get("/state", headers={"Authorization": "Bearer invalid"})
+    assert response.status_code == 401
+    assert "detail" in response.json()
+

--- a/tests/unit/test_study_path_service.py
+++ b/tests/unit/test_study_path_service.py
@@ -1,0 +1,46 @@
+import pytest
+
+from co.services.study_path import StudyPathService
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def set(self, key: str, value, ex=None):
+        self.store[key] = value
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_active_path(db_session):
+    service = StudyPathService(db_session)
+    service._redis = FakeRedis()
+    path = await service.create_study_path("user-1", "track-1", {"level": 1})
+
+    cached = await service._redis.get("study_path:active:user-1")
+    assert cached is not None
+
+    # Remove from DB to force cache usage
+    await db_session.delete(path)
+    await db_session.commit()
+
+    cached_path = await service.get_active_path("user-1")
+    assert cached_path is not None
+    assert cached_path.id == path.id
+    assert cached_path.config["level"] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_path_config(db_session):
+    service = StudyPathService(db_session)
+    service._redis = FakeRedis()
+
+    path = await service.create_study_path("user-1", "track-1", {"level": 1})
+    updated = await service.update_path_config(path.id, {"level": 2})
+    assert updated.config["level"] == 2
+
+    cached_path = await service.get_active_path("user-1")
+    assert cached_path.config["level"] == 2


### PR DESCRIPTION
## Summary
- add StudyPathService with Redis-backed caching for active paths
- introduce JWT AuthMiddleware and integrate with request flow
- extend auth utilities and server wiring, plus unit tests

## Testing
- `ruff check src/co/auth.py src/co/middleware.py src/co/services/study_path.py tests/unit/test_auth_middleware.py tests/unit/test_study_path_service.py`
- `PYTHONPATH=src pytest tests/unit/test_auth_middleware.py tests/unit/test_study_path_service.py tests/unit/test_study_path_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0faf83c1883299fb8299de7535350