### PR TITLE
Add study task retrieval and review queue APIs

### DIFF
--- a/src/co/routes/study_tasks.py
+++ b/src/co/routes/study_tasks.py
@@ -1,0 +1,67 @@
+"""Endpoints for study task retrieval and review queue."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from co.auth import get_current_user
+from co.db.base import get_db
+from co.schemas.study_tasks import (
+    ReviewList,
+    StudyTask as StudyTaskSchema,
+    StudyTaskList,
+)
+from co.services.personalization import PersonalizationService
+from co.services.study_task import StudyTaskService
+
+router = APIRouter()
+
+
+@router.get("/next", response_model=StudyTaskSchema)
+async def get_next_task(
+    db: AsyncSession = Depends(get_db),
+    user_id: UUID = Depends(get_current_user),
+) -> StudyTaskSchema:
+    """Get the next scheduled study task for the authenticated user."""
+    service = StudyTaskService(db)
+    task = await service.get_next_task(user_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="No scheduled tasks")
+    return task
+
+
+@router.get("", response_model=StudyTaskList)
+async def list_tasks(
+    module: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    user_id: UUID = Depends(get_current_user),
+) -> StudyTaskList:
+    """List study tasks for the user with optional filters."""
+    service = StudyTaskService(db)
+    status_enum = None
+    if status:
+        try:
+            from co.models import TaskStatus
+
+            status_enum = TaskStatus(status)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid status")
+    tasks = await service.get_user_tasks(
+        user_id, module=module, status=status_enum, limit=limit
+    )
+    return StudyTaskList(items=tasks)
+
+
+@router.get("/review-due", response_model=ReviewList)
+async def get_due_reviews(
+    limit: int = Query(default=5, ge=1, le=50),
+    db: AsyncSession = Depends(get_db),
+    user_id: UUID = Depends(get_current_user),
+) -> ReviewList:
+    """Return review queue items that are due for the user."""
+    service = PersonalizationService(db)
+    items = await service.get_due_reviews(user_id, limit=limit)
+    return ReviewList(items=items)

--- a/src/co/schemas/study_tasks.py
+++ b/src/co/schemas/study_tasks.py
@@ -1,0 +1,54 @@
+"""Pydantic schemas for study tasks and review queue items."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from co.models import TaskStatus
+
+
+class StudyTask(BaseModel):
+    """Study task representation."""
+
+    id: UUID
+    problem_id: str
+    module: str
+    topic_tags: List[str]
+    difficulty: int
+    scheduled_at: datetime
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    status: TaskStatus
+    score: Optional[float] = None
+    time_spent_seconds: Optional[int] = None
+    hints_used: int
+    meta: Dict[str, Any] = {}
+
+    class Config:
+        from_attributes = True
+
+
+class StudyTaskList(BaseModel):
+    """List of study tasks."""
+
+    items: List[StudyTask]
+
+
+class ReviewItem(BaseModel):
+    """Due review queue item."""
+
+    problem_id: str
+    reason: str
+    next_due_at: datetime
+    bucket: int
+
+    class Config:
+        from_attributes = True
+
+
+class ReviewList(BaseModel):
+    """Collection of due review items."""
+
+    items: List[ReviewItem]

--- a/src/co/server.py
+++ b/src/co/server.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 from co.config import get_settings
 from co.db.base import close_db, init_db
 from co.middleware import AuthMiddleware, RateLimitMiddleware, RequestIDMiddleware
-from co.routes import sessions, submissions, tracks, tutor
+from co.routes import sessions, submissions, study_tasks, tracks, tutor
 
 
 @asynccontextmanager
@@ -52,6 +52,9 @@ def create_app() -> FastAPI:
     # Routes
     app.include_router(tracks.router, prefix="/v1/tracks", tags=["tracks"])
     app.include_router(sessions.router, prefix="/v1/sessions", tags=["sessions"])
+    app.include_router(
+        study_tasks.router, prefix="/v1/study-tasks", tags=["study-tasks"]
+    )
     app.include_router(
         submissions.router, prefix="/v1/submissions", tags=["submissions"]
     )

--- a/src/co/services/personalization.py
+++ b/src/co/services/personalization.py
@@ -192,6 +192,21 @@ class PersonalizationService:
 
         return review_item.problem_id if review_item else None
 
+    async def get_due_reviews(
+        self, user_id: UUID, limit: int = 5
+    ) -> List[ReviewQueue]:
+        """Return review queue items that are due."""
+        result = await self.db.execute(
+            select(ReviewQueue)
+            .where(
+                ReviewQueue.user_id == user_id,
+                ReviewQueue.next_due_at <= datetime.utcnow(),
+            )
+            .order_by(ReviewQueue.next_due_at)
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
     async def update_mastery(
         self,
         user_id: UUID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def app():
 
     from co.config import get_settings
     from co.db.base import close_db, init_db
-    from co.routes import sessions, submissions, tracks, tutor
+    from co.routes import sessions, study_tasks, submissions, tracks, tutor
     from fastapi import FastAPI
 
     settings = get_settings()
@@ -126,6 +126,9 @@ def app():
     # Add only essential routes
     test_app.include_router(tracks.router, prefix="/v1/tracks", tags=["tracks"])
     test_app.include_router(sessions.router, prefix="/v1/sessions", tags=["sessions"])
+    test_app.include_router(
+        study_tasks.router, prefix="/v1/study-tasks", tags=["study-tasks"]
+    )
     test_app.include_router(
         submissions.router, prefix="/v1/submissions", tags=["submissions"]
     )
@@ -306,6 +309,7 @@ def mock_external_services(
         mock_personalization.update_mastery.return_value = None
         mock_personalization.add_to_review_queue.return_value = None
         mock_personalization.mark_review_result.return_value = None
+        mock_personalization.get_due_reviews.return_value = []
         mock_personalization_class.return_value = mock_personalization
         mock_sessions_personalization.return_value = mock_personalization
         mock_task_personalization.return_value = mock_personalization

--- a/tests/unit/test_study_task_service.py
+++ b/tests/unit/test_study_task_service.py
@@ -1,6 +1,6 @@
 import pytest
-from datetime import datetime
-from uuid import UUID
+from datetime import datetime, timedelta
+from uuid import UUID, uuid4
 
 from sqlalchemy import select
 
@@ -56,3 +56,68 @@ async def test_record_evaluation_updates_task_and_review(db_session, test_user_i
     assert evaluation.test_cases_passed == 0
 
     service.personalization.mark_review_result.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_next_task_returns_earliest(db_session, test_user_id):
+    path = StudyPath(user_id=test_user_id, track_id="track1", config={})
+    db_session.add(path)
+    await db_session.commit()
+    await db_session.refresh(path)
+
+    early = StudyTask(
+        path_id=path.id,
+        problem_id="p1",
+        module="arrays",
+        topic_tags=[],
+        difficulty=1,
+        scheduled_at=datetime.utcnow(),
+    )
+    late = StudyTask(
+        path_id=path.id,
+        problem_id="p2",
+        module="arrays",
+        topic_tags=[],
+        difficulty=1,
+        scheduled_at=datetime.utcnow().replace(microsecond=0) + timedelta(hours=1),
+    )
+    db_session.add_all([early, late])
+    await db_session.commit()
+
+    service = StudyTaskService(db_session)
+    task = await service.get_next_task(UUID(test_user_id))
+    assert task.id == early.id
+
+
+@pytest.mark.asyncio
+async def test_get_user_tasks_filters(db_session):
+    user_id = str(uuid4())
+    path = StudyPath(user_id=user_id, track_id="track1", config={})
+    db_session.add(path)
+    await db_session.commit()
+    await db_session.refresh(path)
+
+    task1 = StudyTask(
+        path_id=path.id,
+        problem_id="p1",
+        module="arrays",
+        topic_tags=[],
+        difficulty=1,
+        scheduled_at=datetime.utcnow(),
+    )
+    task2 = StudyTask(
+        path_id=path.id,
+        problem_id="p2",
+        module="graphs",
+        topic_tags=[],
+        difficulty=1,
+        scheduled_at=datetime.utcnow(),
+        status=TaskStatus.completed,
+    )
+    db_session.add_all([task1, task2])
+    await db_session.commit()
+
+    service = StudyTaskService(db_session)
+    tasks = await service.get_user_tasks(UUID(user_id), module="arrays")
+    assert len(tasks) == 1
+    assert tasks[0].module == "arrays"


### PR DESCRIPTION
## Summary
- support querying next or filtered study tasks via new service methods and API endpoints
- expose due review items for spaced repetition
- cover study task retrieval with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a12dc1e3808329aa141d847c18da26