### PR TITLE
feat: add study task scheduling service

### DIFF
--- a/src/co/routes/study_tasks.py
+++ b/src/co/routes/study_tasks.py
@@ -10,12 +10,25 @@ from co.db.base import get_db
 from co.schemas.study_tasks import (
     ReviewList,
     StudyTask as StudyTaskSchema,
+    StudyTaskBatchCreate,
     StudyTaskList,
 )
 from co.services.personalization import PersonalizationService
 from co.services.study_task import StudyTaskService
 
 router = APIRouter()
+
+
+@router.post("/batch", response_model=StudyTaskList)
+async def create_task_batch(
+    payload: StudyTaskBatchCreate,
+    db: AsyncSession = Depends(get_db),
+    user_id: UUID = Depends(get_current_user),
+) -> StudyTaskList:
+    """Create a batch of study tasks for a study path."""
+    service = StudyTaskService(db)
+    tasks = await service.create_tasks_batch(user_id, payload.path_id, payload.tasks)
+    return StudyTaskList(items=tasks)
 
 
 @router.get("/next", response_model=StudyTaskSchema)

--- a/src/co/schemas/study_tasks.py
+++ b/src/co/schemas/study_tasks.py
@@ -9,6 +9,24 @@ from pydantic import BaseModel
 from co.models import TaskStatus
 
 
+class StudyTaskCreate(BaseModel):
+    """Schema for creating a study task."""
+
+    problem_id: str
+    module: str
+    topic_tags: List[str] = []
+    difficulty: int
+    scheduled_at: datetime
+    meta: Dict[str, Any] = {}
+
+
+class StudyTaskBatchCreate(BaseModel):
+    """Request payload for creating multiple study tasks."""
+
+    path_id: UUID
+    tasks: List[StudyTaskCreate]
+
+
 class StudyTask(BaseModel):
     """Study task representation."""
 


### PR DESCRIPTION
## Summary
- add schemas and service method for batch study task creation
- expose POST /v1/study-tasks/batch endpoint to schedule tasks
- cover task scheduling with unit and integration tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a13709cdbc8329900acae260cc490c